### PR TITLE
freezing, skipping uninstall junk on v20 fix

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ gsettings set com.ubuntu.update-notifier show-livepatch-status-icon false
 gsettings set org.gnome.shell.extensions.dash-to-dock click-action 'minimize'
 
 ## Remove junk
-sudo apt-get remove ubuntu-web-launchers thunderbird rhythmbox -y
+sudo apt-get remove thunderbird rhythmbox ubuntu-web-launchers -y
 
 ## Multimedia
 sudo apt-get install -y gimp scribus
@@ -57,7 +57,7 @@ sudo apt-get install -y steam-installer
 ## Music
 curl -sS https://download.spotify.com/debian/pubkey.gpg | sudo apt-key add - 
 echo "deb http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
-sudo apt-get update && sudo apt-get install spotify-client
+sudo apt-get update && sudo apt-get install spotify-client -y
 
 ## Text Editor
 sudo snap install --classic code


### PR DESCRIPTION
while running the script on a v20 the script just skipped the whole #removeJunk part because ubuntu-web-launchers wasn't on my instance so I believe it doesn't come pre-installed now, so I just moved it to be the last thing to remove so at least remove the other things.
the other thing is I just added a -y to the spotify install so the script don't just stop in the middle of the process waiting for 'Y' :rofl: 

thanks Chris the script helped me I'm really thankful :heart: 